### PR TITLE
fix(iOS): 再度問題を解こうとしたときに中断ボタンが表示されない問題を修正

### DIFF
--- a/ios/KanKenApp/KanKenApp/New Group/ResultViewController.swift
+++ b/ios/KanKenApp/KanKenApp/New Group/ResultViewController.swift
@@ -34,6 +34,13 @@ class ResultViewController: UIViewController {
         navigationController?.interactivePopGestureRecognizer?.isEnabled = false
     }
     
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        
+        // navigationBarを表示する
+        navigationController?.setNavigationBarHidden(false, animated: false)
+    }
+    
     private func setLayout() {
         restartButton.layer.cornerRadius = RESTARTBUTTON_CORNER_RADIUS
         toTitleButton.layer.cornerRadius = TOTITLEBUTTON_CORNER_RADIUS

--- a/ios/KanKenApp/KanKenApp/ReviewResult/ReviewResultViewController.swift
+++ b/ios/KanKenApp/KanKenApp/ReviewResult/ReviewResultViewController.swift
@@ -34,5 +34,12 @@ class ReviewResultViewController: UIViewController {
             self.performSegue(withIdentifier: "totitle", sender: nil)
         })
     }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        
+        // navigationBarを表示する
+        navigationController?.setNavigationBarHidden(false, animated: false)
+    }
 
 }


### PR DESCRIPTION
## 概要
* 再度問題を解こうとしたときに、右上のnavigationItemである中断ボタンが表示されなかった
* 結果画面に行ったときにnavigationBarを隠していたため起きていたのでviewが消えるときにnavigationBarを表示するように修正